### PR TITLE
Add localization support

### DIFF
--- a/holds-configurator/holds-configurator.php
+++ b/holds-configurator/holds-configurator.php
@@ -4,9 +4,16 @@
  * Description: Configurateur 3D interactif basé sur Three.js pour prises d'escalade personnalisées.
  * Version: 1.0
  * Author: Loïc Blayo
+ * Text Domain: holds-configurator
+ * Domain Path: /languages
  */
 
-defined('ABSPATH') or die('No direct access');
+defined('ABSPATH') or die( __( 'No direct access', 'holds-configurator' ) );
+
+function holds_configurator_load_textdomain() {
+    load_plugin_textdomain( 'holds-configurator', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+}
+add_action( 'init', 'holds_configurator_load_textdomain' );
 
 function holds_configurator_enqueue_scripts() {
     // Utilisation de la version r147 de Three.js

--- a/holds-configurator/languages/holds-configurator.pot
+++ b/holds-configurator/languages/holds-configurator.pot
@@ -1,0 +1,120 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: Holds Configurator 1.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-01 00:00+0000\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: holds-configurator.php:11
+msgid "No direct access"
+msgstr ""
+
+#: templates/configurator.php:3
+msgid "Bibliothèque de formes :"
+msgstr ""
+
+#: templates/configurator.php:5
+msgid "— Choisir une forme prédéfinie —"
+msgstr ""
+
+#: templates/configurator.php:6
+msgid "Boule / Macro sphère"
+msgstr ""
+
+#: templates/configurator.php:7
+msgid "Sloper (plat bombé)"
+msgstr ""
+
+#: templates/configurator.php:8
+msgid "Edge (règle)"
+msgstr ""
+
+#: templates/configurator.php:9
+msgid "Crimp (arête fine)"
+msgstr ""
+
+#: templates/configurator.php:10
+msgid "Pinch (pince)"
+msgstr ""
+
+#: templates/configurator.php:11
+msgid "Jug (bac)"
+msgstr ""
+
+#: templates/configurator.php:12
+msgid "Mini-jug"
+msgstr ""
+
+#: templates/configurator.php:13
+msgid "Pocket (trou)"
+msgstr ""
+
+#: templates/configurator.php:14
+msgid "Blob (galet mutant)"
+msgstr ""
+
+#: templates/configurator.php:15
+msgid "Hoof (sabot)"
+msgstr ""
+
+#: templates/configurator.php:20
+msgid "Forme :"
+msgstr ""
+
+#: templates/configurator.php:22
+msgid "Cube"
+msgstr ""
+
+#: templates/configurator.php:23
+msgid "Sphère"
+msgstr ""
+
+#: templates/configurator.php:24
+msgid "Cylindre"
+msgstr ""
+
+#: templates/configurator.php:25
+msgid "Cône"
+msgstr ""
+
+#: templates/configurator.php:26
+msgid "Pyramide"
+msgstr ""
+
+#: templates/configurator.php:27
+msgid "Prisme triangulaire"
+msgstr ""
+
+#: templates/configurator.php:28
+msgid "Galet"
+msgstr ""
+
+#: templates/configurator.php:33
+msgid "Mode trou / pocket"
+msgstr ""
+
+#: templates/configurator.php:34
+msgid "Mode libre"
+msgstr ""
+
+#: templates/configurator.php:35
+msgid "(Glisser un sommet rouge)"
+msgstr ""
+
+#: templates/configurator.php:38
+msgid "Rugosité :"
+msgstr ""
+
+#: templates/configurator.php:41
+msgid "Aplatir la base"
+msgstr ""
+
+#: templates/configurator.php:44
+msgid "Exporter STL"
+msgstr ""
+
+#: templates/configurator.php:47
+msgid "Astuce : Utilise la bibliothèque, règle les paramètres, active la rugosité ou mode libre, puis clique sur “Aplatir la base” si besoin."
+msgstr ""

--- a/holds-configurator/templates/configurator.php
+++ b/holds-configurator/templates/configurator.php
@@ -1,47 +1,49 @@
 <div id="holds-canvas-container">
     <div style="margin-bottom:10px;">
-        <label for="preset">Bibliothèque de formes :</label>
+        <label for="preset"><?php _e('Bibliothèque de formes :', 'holds-configurator'); ?></label>
         <select id="preset">
-            <option value="">— Choisir une forme prédéfinie —</option>
-            <option value="ball">Boule / Macro sphère</option>
-            <option value="sloper">Sloper (plat bombé)</option>
-            <option value="edge">Edge (règle)</option>
-            <option value="crimp">Crimp (arête fine)</option>
-            <option value="pinch">Pinch (pince)</option>
-            <option value="jug">Jug (bac)</option>
-            <option value="miniJug">Mini-jug</option>
-            <option value="pocket">Pocket (trou)</option>
-            <option value="blob">Blob (galet mutant)</option>
-            <option value="hoof">Hoof (sabot)</option>
+            <option value=""><?php _e('— Choisir une forme prédéfinie —', 'holds-configurator'); ?></option>
+            <option value="ball"><?php _e('Boule / Macro sphère', 'holds-configurator'); ?></option>
+            <option value="sloper"><?php _e('Sloper (plat bombé)', 'holds-configurator'); ?></option>
+            <option value="edge"><?php _e('Edge (règle)', 'holds-configurator'); ?></option>
+            <option value="crimp"><?php _e('Crimp (arête fine)', 'holds-configurator'); ?></option>
+            <option value="pinch"><?php _e('Pinch (pince)', 'holds-configurator'); ?></option>
+            <option value="jug"><?php _e('Jug (bac)', 'holds-configurator'); ?></option>
+            <option value="miniJug"><?php _e('Mini-jug', 'holds-configurator'); ?></option>
+            <option value="pocket"><?php _e('Pocket (trou)', 'holds-configurator'); ?></option>
+            <option value="blob"><?php _e('Blob (galet mutant)', 'holds-configurator'); ?></option>
+            <option value="hoof"><?php _e('Hoof (sabot)', 'holds-configurator'); ?></option>
         </select>
     </div>
     <canvas id="holds-canvas" style="width: 100%; height: 400px; display: block; background: #fff"></canvas>
     <div style="margin-top:16px;">
-        <label for="shape">Forme :</label>
+        <label for="shape"><?php _e('Forme :', 'holds-configurator'); ?></label>
         <select id="shape">
-            <option value="cube">Cube</option>
-            <option value="sphere">Sphère</option>
-            <option value="cylinder">Cylindre</option>
-            <option value="cone">Cône</option>
-            <option value="pyramid">Pyramide</option>
-            <option value="prism">Prisme triangulaire</option>
-            <option value="galet">Galet</option>
+            <option value="cube"><?php _e('Cube', 'holds-configurator'); ?></option>
+            <option value="sphere"><?php _e('Sphère', 'holds-configurator'); ?></option>
+            <option value="cylinder"><?php _e('Cylindre', 'holds-configurator'); ?></option>
+            <option value="cone"><?php _e('Cône', 'holds-configurator'); ?></option>
+            <option value="pyramid"><?php _e('Pyramide', 'holds-configurator'); ?></option>
+            <option value="prism"><?php _e('Prisme triangulaire', 'holds-configurator'); ?></option>
+            <option value="galet"><?php _e('Galet', 'holds-configurator'); ?></option>
         </select>
         <span id="param-controls"></span>
     </div>
     <div style="margin-top:8px;">
-        <label style="display:inline-block;"><input type="checkbox" id="pocket" style="vertical-align:middle;"> Mode trou / pocket</label>
-        <button id="mode-libre-btn" type="button" style="margin-left:12px;">Mode libre</button>
-        <span id="mode-libre-label" style="font-size:0.9em;color:#2194ce;display:none;">(Glisser un sommet rouge)</span>
+        <label style="display:inline-block;"><input type="checkbox" id="pocket" style="vertical-align:middle;"> <?php _e('Mode trou / pocket', 'holds-configurator'); ?></label>
+        <button id="mode-libre-btn" type="button" style="margin-left:12px;"><?php _e('Mode libre', 'holds-configurator'); ?></button>
+        <span id="mode-libre-label" style="font-size:0.9em;color:#2194ce;display:none;"><?php _e('(Glisser un sommet rouge)', 'holds-configurator'); ?></span>
     </div>
     <div style="margin-top:12px;">
-        <label for="rugosite">Rugosité :</label>
+        <label for="rugosite"><?php _e('Rugosité :', 'holds-configurator'); ?></label>
         <input type="range" id="rugosite" min="0" max="2" value="0" step="0.01" style="width:150px;">
         <span id="rugosite-value">0</span>
-        <button id="flatten-btn" type="button" style="margin-left:18px;">Aplatir la base</button>
+        <button id="flatten-btn" type="button" style="margin-left:18px;"><?php _e('Aplatir la base', 'holds-configurator'); ?></button>
     </div>
     <div style="margin-top:18px;">
-        <button id="export-btn">Exporter STL</button>
+        <button id="export-btn"><?php _e('Exporter STL', 'holds-configurator'); ?></button>
     </div>
-    <p style="margin-top:10px;font-size:0.92em;color:#888;">Astuce : Utilise la bibliothèque, règle les paramètres, active la rugosité ou mode libre, puis clique sur “Aplatir la base” si besoin.</p>
+    <p style="margin-top:10px;font-size:0.92em;color:#888;">
+        <?php _e('Astuce : Utilise la bibliothèque, règle les paramètres, active la rugosité ou mode libre, puis clique sur “Aplatir la base” si besoin.', 'holds-configurator'); ?>
+    </p>
 </div>


### PR DESCRIPTION
## Summary
- make plugin localizable with a text domain header
- load the text domain on `init`
- translate the configurator template strings
- add translation template file

## Testing
- `php -l holds-configurator/holds-configurator.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_b_684846e2708483249b55bad7666cb0b6