### PR TITLE
Add server-side STL saving via AJAX

### DIFF
--- a/holds-configurator/assets/js/configurator.js
+++ b/holds-configurator/assets/js/configurator.js
@@ -372,14 +372,31 @@ document.addEventListener('DOMContentLoaded', () => {
     renderer.setSize(canvas.clientWidth, 400, false);
   });
 
+  async function sendSTLToServer(stlString) {
+    const response = await fetch(holdsConf.ajax_url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
+      },
+      body: new URLSearchParams({
+        action: 'save_stl',
+        nonce: holdsConf.nonce,
+        stl: stlString
+      })
+    });
+    return response.json();
+  }
+
   document.getElementById('export-btn').addEventListener('click', () => {
     const exporter = new THREE.STLExporter();
     const stlString = exporter.parse(mesh);
-    const blob = new Blob([stlString], { type: 'text/plain' });
-    const a = document.createElement('a');
-    a.href = URL.createObjectURL(blob);
-    a.download = 'custom-hold.stl';
-    a.click();
+    sendSTLToServer(stlString).then(result => {
+      if (result.success) {
+        alert('STL saved at ' + result.data.url);
+      } else {
+        alert('Error saving STL');
+      }
+    });
   });
 
   updateParamControls();

--- a/holds-configurator/holds-configurator.php
+++ b/holds-configurator/holds-configurator.php
@@ -23,6 +23,11 @@ function holds_configurator_enqueue_scripts() {
         null,
         true
     );
+
+    wp_localize_script('holds-configurator', 'holdsConf', [
+        'ajax_url' => admin_url('admin-ajax.php'),
+        'nonce'    => wp_create_nonce('save_stl'),
+    ]);
 }
 add_action('wp_enqueue_scripts', 'holds_configurator_enqueue_scripts');
 
@@ -32,3 +37,32 @@ function holds_configurator_shortcode() {
     return ob_get_clean();
 }
 add_shortcode('holds_configurator', 'holds_configurator_shortcode');
+
+add_action('wp_ajax_nopriv_save_stl', 'holds_configurator_save_stl');
+add_action('wp_ajax_save_stl', 'holds_configurator_save_stl');
+
+function holds_configurator_save_stl() {
+    check_ajax_referer('save_stl', 'nonce');
+
+    $stl_data = isset($_POST['stl']) ? wp_unslash($_POST['stl']) : '';
+    if (empty($stl_data)) {
+        wp_send_json_error('No STL data');
+    }
+
+    $upload = wp_upload_dir();
+    $dir = trailingslashit($upload['basedir']) . 'holds-configurator';
+    if (!file_exists($dir)) {
+        wp_mkdir_p($dir);
+    }
+
+    $filename = 'hold-' . uniqid() . '.stl';
+    $filepath = trailingslashit($dir) . $filename;
+
+    $result = file_put_contents($filepath, $stl_data);
+    if ($result === false) {
+        wp_send_json_error('Could not save file');
+    }
+
+    $url = trailingslashit($upload['baseurl']) . 'holds-configurator/' . $filename;
+    wp_send_json_success(['url' => $url, 'path' => $filepath]);
+}


### PR DESCRIPTION
## Summary
- localize script with AJAX URL and nonce
- handle `save_stl` AJAX action on both public and logged in users
- write uploaded STL string to the uploads directory
- send STL data from the configurator via fetch

## Testing
- `php -l holds-configurator/holds-configurator.php` *(fails: command not found)*
- `node -v`

------
https://chatgpt.com/codex/tasks/task_b_684848ab53108324b9875d8eeea399e2